### PR TITLE
Allow user to specify custom prefix for resource files.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,8 @@ find_package(ECM REQUIRED NO_MODULE)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${ECM_MODULE_PATH})
 
+include(GNUInstallDirs)
+
 add_subdirectory(polkit-agent)
 add_subdirectory(screen-brightness)
 add_subdirectory(session)

--- a/cpufreq/CMakeLists.txt
+++ b/cpufreq/CMakeLists.txt
@@ -13,5 +13,11 @@ target_link_libraries(${TARGET}
         Qt5::X11Extras
 )
 
+configure_file(
+    org.cutefish.cpufreq.pkexec.policy.in
+    org.cutefish.cpufreq.pkexec.policy
+    @ONLY
+)
+
 install(TARGETS ${TARGET} DESTINATION ${CMAKE_INSTALL_BINDIR})
-install(FILES org.cutefish.cpufreq.pkexec.policy DESTINATION /usr/share/polkit-1/actions/)
+install(FILES org.cutefish.cpufreq.pkexec.policy DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/polkit-1/actions/)

--- a/cpufreq/org.cutefish.cpufreq.pkexec.policy.in
+++ b/cpufreq/org.cutefish.cpufreq.pkexec.policy.in
@@ -10,6 +10,6 @@
       <allow_inactive>no</allow_inactive>
       <allow_active>yes</allow_active>
     </defaults>
-    <annotate key="org.freedesktop.policykit.exec.path">/usr/bin/cutefish-cpufreq</annotate>
+    <annotate key="org.freedesktop.policykit.exec.path">@CMAKE_INSTALL_FULL_BINDIR@/cutefish-cpufreq</annotate>
   </action>
 </policyconfig>

--- a/polkit-agent/CMakeLists.txt
+++ b/polkit-agent/CMakeLists.txt
@@ -41,8 +41,8 @@ install(TARGETS cutefish-polkit-agent
 
 install(FILES
 cutefish-polkit-agent.desktop
-    DESTINATION "/etc/xdg/autostart"
+    DESTINATION "${CMAKE_INSTALL_FULL_SYSCONFDIR}/xdg/autostart"
     COMPONENT Runtime
 )
 
-install(FILES ${QM_FILES} DESTINATION /usr/share/cutefish-polkit-agent/translations)
+install(FILES ${QM_FILES} DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/cutefish-polkit-agent/translations)

--- a/screen-brightness/CMakeLists.txt
+++ b/screen-brightness/CMakeLists.txt
@@ -17,5 +17,11 @@ target_link_libraries(${PROJECT_NAME}
         Qt5::Widgets
 )
 
+configure_file(
+    org.cutefish.brightness.pkexec.policy.in
+    org.cutefish.brightness.pkexec.policy
+    @ONLY
+)
+
 install(TARGETS ${PROJECT_NAME} RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
-install(FILES org.cutefish.brightness.pkexec.policy DESTINATION /usr/share/polkit-1/actions/)
+install(FILES org.cutefish.brightness.pkexec.policy DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/polkit-1/actions/)

--- a/screen-brightness/org.cutefish.brightness.pkexec.policy.in
+++ b/screen-brightness/org.cutefish.brightness.pkexec.policy.in
@@ -10,6 +10,6 @@
       <allow_inactive>no</allow_inactive>
       <allow_active>yes</allow_active>
     </defaults>
-    <annotate key="org.freedesktop.policykit.exec.path">/usr/bin/cutefish-screen-brightness</annotate>
+    <annotate key="org.freedesktop.policykit.exec.path">@CMAKE_INSTALL_FULL_BINDIR@/cutefish-screen-brightness</annotate>
   </action>
 </policyconfig>

--- a/session/CMakeLists.txt
+++ b/session/CMakeLists.txt
@@ -31,4 +31,4 @@ target_link_libraries(${TARGET}
 )
 
 install(TARGETS ${TARGET} DESTINATION ${CMAKE_INSTALL_BINDIR})
-install(FILES cutefish-xsession.desktop DESTINATION /usr/share/xsessions/)
+install(FILES cutefish-xsession.desktop DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/xsessions/)

--- a/settings-daemon/CMakeLists.txt
+++ b/settings-daemon/CMakeLists.txt
@@ -73,4 +73,4 @@ add_custom_target(translations DEPENDS ${QM_FILES} SOURCES ${TS_FILES})
 add_dependencies(${TARGET} translations)
 
 install(TARGETS ${TARGET} DESTINATION ${CMAKE_INSTALL_BINDIR})
-install(FILES ${QM_FILES} DESTINATION /usr/share/${TARGET}/translations)
+install(FILES ${QM_FILES} DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/${TARGET}/translations)

--- a/shutdown-ui/CMakeLists.txt
+++ b/shutdown-ui/CMakeLists.txt
@@ -18,6 +18,6 @@ file(GLOB TS_FILES translations/*.ts)
 qt5_create_translation(QM_FILES ${TS_FILES})
 add_custom_target(shutdown-translations DEPENDS ${QM_FILES} SOURCES ${TS_FILES})
 add_dependencies(cutefish-shutdown shutdown-translations)
-install(FILES ${QM_FILES} DESTINATION /usr/share/cutefish-shutdown/translations)
+install(FILES ${QM_FILES} DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/cutefish-shutdown/translations)
 
 install(TARGETS cutefish-shutdown RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})


### PR DESCRIPTION
This PR is successor of #9, removes all hardcoded path in build system.

There's still some hardcoded path in C++ source. IMO, there's better way to fix them, maybe add new function to search those resources(e.g. search environment variable first, then search FHS path, finally search builtin path)

---

* CMakeLists.txt: include GNUInstallDirs.

* cpufreq/CMakeLists.txt: Replace hardcoded path with ${CMAKE_INSTALL_XXXXX} variables.
* session/CMakeLists.txt: Ditto.
* shutdown-ui/CMakeLists.txt: Ditto.
* setting-daemon/CMakeLists.txt: Ditto.
* screen-brightness/CMakeLists.txt: Ditto.
* polkit-agent/CMakeLists.txt: Ditto.

* screen-brightness/org.cutefish.brightness.pkexec.policy:

Rename to file with ".in" extension.
Replace hardcoded path with @CMAKE_INSTALL_FULL_XXXXX@ variables.

* cpufreq/org.cutefish.cpufreq.pkexec.policy: Ditto.