### PR TITLE
Fix: Make Super Great Again

### DIFF
--- a/chotkeys/application.cpp
+++ b/chotkeys/application.cpp
@@ -21,6 +21,7 @@
 #include "hotkeys.h"
 
 #include <QProcess>
+#include <QDebug>
 
 Application::Application(QObject *parent)
     : QObject(parent)
@@ -37,11 +38,13 @@ void Application::setupShortcuts()
     m_hotKeys->registerKey(QKeySequence(Qt::CTRL + Qt::ALT + Qt::Key_Delete));
     m_hotKeys->registerKey(QKeySequence(Qt::CTRL + Qt::ALT + Qt::Key_A));
     m_hotKeys->registerKey(QKeySequence(Qt::META + Qt::Key_L));
-    // m_hotKeys->registerKey(QKeySequence(Qt::Key_Super_L));
+    //m_hotKeys->registerKey(QKeySequence(Qt::META + Qt::Key_6));
+    m_hotKeys->registerKey(647);
 }
 
 void Application::onPressed(QKeySequence keySeq)
 {
+
     if (keySeq.toString() == "Ctrl+Alt+Del") {
         QProcess::startDetached("cutefish-shutdown", QStringList());
     }
@@ -53,11 +56,8 @@ void Application::onPressed(QKeySequence keySeq)
     if (keySeq.toString() == "Ctrl+Alt+A") {
         QProcess::startDetached("cutefish-screenshot", QStringList());
     }
-}
 
-void Application::onReleased(QKeySequence keySeq)
-{
-    if (keySeq == QKeySequence(Qt::Key_Super_L)) {
+    if (keySeq.toString() == "Ʇ") {
         QProcess::startDetached("cutefish-launcher", QStringList());
     }
 }

--- a/chotkeys/main.cpp
+++ b/chotkeys/main.cpp
@@ -26,13 +26,13 @@ int main(int argc, char *argv[])
     QApplication a(argc, argv);
     a.setQuitOnLastWindowClosed(true);
 
-//    if (!QDBusConnection::sessionBus().registerService("com.cutefish.Chotkeys")) {
-//        return -1;
-//    }
+    if (!QDBusConnection::sessionBus().registerService("com.cutefish.Chotkeys")) {
+        return -1;
+    }
 
-//    if (!QDBusConnection::sessionBus().registerObject("/Chotkeys", &a)) {
-//        return -1;
-//    }
+    if (!QDBusConnection::sessionBus().registerObject("/Chotkeys", &a)) {
+        return -1;
+    }
 
     Application app;
     return a.exec();


### PR DESCRIPTION
Not entirely certain this is correct but theoretically:

* Key_Super_L was not working anymore under Arch Linux/Qt 5.15.7
* Could not register META under Key_Meta/Super/etc so figured out the code (647) and used that instead
* For some reason this comes out in keySeq as Ʇ (What is this, who knows :100: )
* Simply added a line to capture this once the shortcut is registered and run cutefish-launcher

Works on my machine and has restored my meta/super/windows key, I'm not familiar enough with qt to know if the code or keySeq will be different on other computers. I thought I'd make this PR anyway in the hope that someone can use it who has lost their meta key or add to the PR to complete the fix