### PR TITLE
fix: 意外导致desktop 退出问题，维护启动程序运行

### DIFF
--- a/session/processmanager.cpp
+++ b/session/processmanager.cpp
@@ -142,6 +142,11 @@ void ProcessManager::startDesktopProcess()
         process->start();
         process->waitForStarted();
 
+		QObject::connect(process, static_cast<void(QProcess::*)(int, QProcess::ExitStatus)>(&QProcess::finished),
+                         [process] (int exitCode, QProcess::ExitStatus exitStatus) {
+            process->start();
+        });
+		
         qDebug() << "Load DE components: " << pair.first << pair.second;
 
         // Add to map


### PR DESCRIPTION
关闭窗体时偶现 cutefish-filemanager --desktop 进程结束，
需要去除cutefish-clipboard的启动，否则剪切板无法正常使用，
我在其他平台进行的编译和运行，cutefish-clipboard的启动会造成首次复制卡顿，我没确定原因