### PR TITLE
fix: 意外导致desktop 推出问题

### DIFF
--- a/session/processmanager.cpp
+++ b/session/processmanager.cpp
@@ -120,7 +120,7 @@ void ProcessManager::startDesktopProcess()
     list << qMakePair(QString("cutefish-filemanager"), QStringList("--desktop"));
     list << qMakePair(QString("cutefish-launcher"), QStringList());
     list << qMakePair(QString("cutefish-powerman"), QStringList());
-    list << qMakePair(QString("cutefish-clipboard"), QStringList());
+//    list << qMakePair(QString("cutefish-clipboard"), QStringList());
 
     // For CutefishOS.
     if (QFile("/usr/bin/cutefish-welcome").exists() &&
@@ -147,6 +147,10 @@ void ProcessManager::startDesktopProcess()
         // Add to map
         if (process->exitCode() == 0) {
             m_autoStartProcess.insert(pair.first, process);
+			QObject::connect(process, static_cast<void(QProcess::*)(int, QProcess::ExitStatus)>(&QProcess::finished),
+                         [process] (int exitCode, QProcess::ExitStatus exitStatus) {
+            process->start();
+			});
         } else {
             process->deleteLater();
         }


### PR DESCRIPTION
我在其他平台进行的编译和运行，
关闭窗体时偶现 cutefish-filemanager --desktop 进程结束，
需要去除cutefish-clipboard的启动，否则剪切板无法正常使用。
cutefish-clipboard的启动会造成首次复制卡顿，我没确定原因。